### PR TITLE
Support different entry points in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Append a `/` at the end of a URL to view a listing of all the files in a package
 
   <dt>?module</dt>
   <dd>Expands all ["bare" `import` specifiers](https://html.spec.whatwg.org/multipage/webappapis.html#resolve-a-module-specifier) in JavaScript modules to unpkg URLs. This feature is *very experimental*</dd>
+
+  <dt>?bundle</dt>
+  <dd>Returns the specified bundle, or the default one if it is not available</dd>
 </dl>
 
 ### Cache Behavior

--- a/docs/home.md
+++ b/docs/home.md
@@ -33,6 +33,9 @@ Append a `/` at the end of a URL to view a listing of all the files in a package
 
   <dt>`?module`</dt>
   <dd>Expands all ["bare" `import` specifiers](https://html.spec.whatwg.org/multipage/webappapis.html#resolve-a-module-specifier) in JavaScript modules to unpkg URLs. This feature is *very experimental*</dd>
+
+  <dt>`?bundle`</dt>
+  <dd>Returns the specified bundle, or the default one if it is not available</dd>
 </dl>
 
 ### Workflow

--- a/server/middleware/validateQuery.js
+++ b/server/middleware/validateQuery.js
@@ -3,7 +3,8 @@ const createSearch = require("../utils/createSearch");
 const knownQueryParams = {
   main: true, // Deprecated, see #63
   meta: true,
-  module: true
+  module: true,
+  bundle: true
 };
 
 function isKnownQueryParam(param) {


### PR DESCRIPTION
This PR adds the ability to load different entry points by adding the `bundle` query parameter to a "bare" URL.

The way it works is based on the syntax proposed by @mjackson on https://github.com/unpkg/unpkg/issues/93#issuecomment-385816263

_**Note:** the usage of the `unpkg` field as an object in `package.json` is still undocumented, not sure where the documentation should be added though_

Resolves: #93 
