### PR TITLE
Check for non-https, non-standard port registry URLs

### DIFF
--- a/modules/utils/fetchNpmPackage.js
+++ b/modules/utils/fetchNpmPackage.js
@@ -1,5 +1,7 @@
 const url = require("url");
-const https = require("https");
+const https = require(process.env.NPM_REGISTRY_URL.indexOf("http:") !== 0
+  ? "https"
+  : "http");
 const gunzip = require("gunzip-maybe");
 const tar = require("tar-stream");
 
@@ -17,8 +19,10 @@ function fetchNpmPackage(packageConfig) {
       tarballURL
     );
 
-    const { hostname, pathname } = url.parse(tarballURL);
+    const { hostname, pathname, protocol, port } = url.parse(tarballURL);
     const options = {
+      protocol: protocol,
+      port: port,
       agent: agent,
       hostname: hostname,
       path: pathname

--- a/modules/utils/fetchNpmPackage.js
+++ b/modules/utils/fetchNpmPackage.js
@@ -1,5 +1,6 @@
 const url = require("url");
-const https = require(process.env.NPM_REGISTRY_URL.indexOf("http:") !== 0
+const serverConfig = require("../serverConfig");
+const https = require(serverConfig.registryURL.indexOf("http:") !== 0
   ? "https"
   : "http");
 const gunzip = require("gunzip-maybe");

--- a/modules/utils/fetchNpmPackageInfo.js
+++ b/modules/utils/fetchNpmPackageInfo.js
@@ -1,7 +1,7 @@
 const url = require("url");
-const https = require(process.env.NPM_REGISTRY_URL.indexOf("http:") !== 0 ? "https" : "http");
-
 const serverConfig = require("../serverConfig");
+const https = require(serverConfig.registryURL.indexOf("http:") !== 0 ? "https" : "http");
+
 const bufferStream = require("./bufferStream");
 const agent = require("./registryAgent");
 const logging = require("./logging");

--- a/modules/utils/fetchNpmPackageInfo.js
+++ b/modules/utils/fetchNpmPackageInfo.js
@@ -1,5 +1,5 @@
 const url = require("url");
-const https = require("https");
+const https = require(process.env.NPM_REGISTRY_URL.indexOf("http:") !== 0 ? "https" : "http");
 
 const serverConfig = require("../serverConfig");
 const bufferStream = require("./bufferStream");
@@ -21,8 +21,10 @@ function fetchNpmPackageInfo(packageName) {
 
     logging.debug("Fetching package info for %s from %s", packageName, infoURL);
 
-    const { hostname, pathname } = url.parse(infoURL);
+    const { hostname, pathname, port, protocol } = url.parse(infoURL);
     const options = {
+      protocol: protocol,
+      port: port,
       agent: agent,
       hostname: hostname,
       path: pathname,

--- a/modules/utils/registryAgent.js
+++ b/modules/utils/registryAgent.js
@@ -1,6 +1,5 @@
-const https = require(process.env.NPM_REGISTRY_URL.indexOf("http:") !== 0
-  ? "https"
-  : "http");
+const serverConfig = require("../serverConfig");
+const https = require(serverConfig.registryURL.indexOf("http:") !== 0 ? "https" : "http");
 
 const agent = new https.Agent({
   keepAlive: true

--- a/modules/utils/registryAgent.js
+++ b/modules/utils/registryAgent.js
@@ -1,4 +1,6 @@
-const https = require("https");
+const https = require(process.env.NPM_REGISTRY_URL.indexOf("http:") !== 0
+  ? "https"
+  : "http");
 
 const agent = new https.Agent({
   keepAlive: true


### PR DESCRIPTION
- conditionally require either http or http based on process.env.NPM_REGISTRY_URL
- pass port and protocol to all http(s).get calls

So I use a local npm registry with http and port 4873 (verdaccio), but currently the base unpkg server won't use nonstandard ports or http. This is a fairly small edit that shouldn't affect current users, unless they're passing in a custom npm registry and assuming it will get parsed incorrectly.

I'm not a huge fan of the conditional require based on indexOf the registry url, I was also thinking about turning the agent into a builder to pass the http(s) object to?

Edit: Looks like the npm registry isn't passed by default so travis fails when trying to call methods on it, will fix.