### PR TITLE
add space between in and `package.json`

### DIFF
--- a/modules/client/main/App.js
+++ b/modules/client/main/App.js
@@ -283,7 +283,7 @@ export default class App extends React.Component {
             <a href="https://docs.npmjs.com/files/package.json#files">
               files array
             </a>{' '}
-            in
+            in{' '}
             <code>package.json</code>
           </li>
           <li>


### PR DESCRIPTION
Add a space (with `{' '}`) between "in" and "`package.json`" in the text on the landing page

![image](https://user-images.githubusercontent.com/13088589/53861212-31180400-3fec-11e9-8097-2fedf09fa95d.png)
