### PR TITLE
Preserve whitespace semantics when resolving imports

### DIFF
--- a/modules/utils/rewriteBareModuleIdentifiers.js
+++ b/modules/utils/rewriteBareModuleIdentifiers.js
@@ -16,6 +16,10 @@ export default function rewriteBareModuleIdentifiers(code, packageConfig) {
     // because we haven't installed dependencies so
     // we can't load plugins; see #84
     babelrc: false,
+    // Make a reasonable attempt to preserve whitespace
+    // from the original file. This ensures minified
+    // .mjs stays minified; see #149
+    retainLines: true,
     plugins: [unpkgRewrite(origin, dependencies)]
   };
 


### PR DESCRIPTION
This Babel option preserves whitespace semantics (and thus minification) when transforming bare import specifiers (fixes #149).

/cc @mjackson 
